### PR TITLE
fix: vertical definition list stacking for screens bigger than defined

### DIFF
--- a/src/content/List/List.scss
+++ b/src/content/List/List.scss
@@ -94,7 +94,7 @@
   }
 
   @each $breakpoint in map-keys(screen-get()) {
-    @include screen-up($breakpoint) {
+    @include screen-down($breakpoint) {
       &--#{$breakpoint}-vertical {
         @include make-vertical($self);
       }


### PR DESCRIPTION
The documentation of the List styles states that for example the class `olt-List--sm-vertical` should stack the category and value on top of each other for screens <= small screen. 

In fact, it's having the opposite effect (screens >= small screen) which is fixed in this PR

