### PR TITLE
feat: chip fixes

### DIFF
--- a/src/components/Chip/Chip.md
+++ b/src/components/Chip/Chip.md
@@ -439,7 +439,7 @@ Each _Chip_ can have an icon rendered on the left or on the right side by adding
 ### Bubble
 
 Each _Chip_ can have an additional bubble rendered on the top right side by
-adding `--bubble` modifier and a descendant `-bubble` component inside the
+adding `--withBubble` modifier and a descendant `-bubble` component inside the
 _Chip_.
 
 ```bubbles.html

--- a/src/components/Chip/Chip.md
+++ b/src/components/Chip/Chip.md
@@ -63,13 +63,13 @@ names.
               <span class="olt-Chip" data-icon-right="add">Label</span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--bubble">
+              <span class="olt-Chip olt-Chip--withBubble">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--bubble" data-icon-left="add">
+              <span class="olt-Chip olt-Chip--withBubble" data-icon-left="add">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
@@ -106,13 +106,13 @@ names.
               <span class="olt-Chip olt-Chip--dark" data-icon-right="add">Label</span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--dark olt-Chip--bubble">
+              <span class="olt-Chip olt-Chip--dark olt-Chip--withBubble">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--dark olt-Chip--bubble" data-icon-left="add">
+              <span class="olt-Chip olt-Chip--dark olt-Chip--withBubble" data-icon-left="add">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
@@ -149,13 +149,13 @@ names.
               <span class="olt-Chip olt-Chip--light" data-icon-right="add">Label</span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--light olt-Chip--bubble">
+              <span class="olt-Chip olt-Chip--light olt-Chip--withBubble">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--light olt-Chip--bubble" data-icon-left="add">
+              <span class="olt-Chip olt-Chip--light olt-Chip--withBubble" data-icon-left="add">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
@@ -192,13 +192,13 @@ names.
               <span class="olt-Chip olt-Chip--primary" data-icon-right="add">Label</span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--primary olt-Chip--bubble">
+              <span class="olt-Chip olt-Chip--primary olt-Chip--withBubble">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--primary olt-Chip--bubble" data-icon-left="add">
+              <span class="olt-Chip olt-Chip--primary olt-Chip--withBubble" data-icon-left="add">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
@@ -263,13 +263,13 @@ names.
               <span class="olt-Chip olt-Chip--error" data-icon-left="close">Label</span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--error olt-Chip--bubble">
+              <span class="olt-Chip olt-Chip--error olt-Chip--withBubble">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--error olt-Chip--bubble" data-icon-left="close">
+              <span class="olt-Chip olt-Chip--error olt-Chip--withBubble" data-icon-left="close">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
@@ -296,13 +296,13 @@ names.
               <span class="olt-Chip olt-Chip--success" data-icon-left="check">Label</span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--success olt-Chip--bubble">
+              <span class="olt-Chip olt-Chip--success olt-Chip--withBubble">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--success olt-Chip--bubble" data-icon-left="check">
+              <span class="olt-Chip olt-Chip--success olt-Chip--withBubble" data-icon-left="check">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
@@ -329,13 +329,13 @@ names.
               <span class="olt-Chip olt-Chip--info" data-icon-left="info">Label</span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--info olt-Chip--bubble">
+              <span class="olt-Chip olt-Chip--info olt-Chip--withBubble">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
             </div>
             <div class="demo-content">
-              <span class="olt-Chip olt-Chip--info olt-Chip--bubble" data-icon-left="info">
+              <span class="olt-Chip olt-Chip--info olt-Chip--withBubble" data-icon-left="info">
                 Label
                 <span class="olt-Chip-bubble">42</span>
               </span>
@@ -443,27 +443,27 @@ adding `--bubble` modifier and a descendant `-bubble` component inside the
 _Chip_.
 
 ```bubbles.html
-<span class="olt-Chip olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--withBubble">
   Default
   <span class="olt-Chip-bubble">42</span>
 </span>
-<span class="olt-Chip olt-Chip--dark olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--dark olt-Chip--withBubble">
   Dark
   <span class="olt-Chip-bubble">42</span>
 </span>
-<span class="olt-Chip olt-Chip--primary olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--primary olt-Chip--withBubble">
   Primary
   <span class="olt-Chip-bubble">42</span>
 </span>
-<span class="olt-Chip olt-Chip--error olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--error olt-Chip--withBubble">
   Error
   <span class="olt-Chip-bubble">42</span>
 </span>
-<span class="olt-Chip olt-Chip--success olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--success olt-Chip--withBubble">
   Success
   <span class="olt-Chip-bubble">42</span>
 </span>
-<span class="olt-Chip olt-Chip--info olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--info olt-Chip--withBubble">
   Info
   <span class="olt-Chip-bubble">42</span>
 </span>
@@ -473,27 +473,27 @@ The _Chip_'s bubble can also be an icon by adding `data-icon` to the bubble
 element.
 
 ```bubble-icons.html
-<span class="olt-Chip olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--withBubble">
   Default
   <span class="olt-Chip-bubble" data-icon="add"></span>
 </span>
-<span class="olt-Chip olt-Chip--dark olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--dark olt-Chip--withBubble">
   Dark
   <span class="olt-Chip-bubble" data-icon="add"></span>
 </span>
-<span class="olt-Chip olt-Chip--primary olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--primary olt-Chip--withBubble">
   Primary
   <span class="olt-Chip-bubble" data-icon="add"></span>
 </span>
-<span class="olt-Chip olt-Chip--error olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--error olt-Chip--withBubble">
   Error
   <span class="olt-Chip-bubble" data-icon="add"></span>
 </span>
-<span class="olt-Chip olt-Chip--success olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--success olt-Chip--withBubble">
   Success
   <span class="olt-Chip-bubble" data-icon="add"></span>
 </span>
-<span class="olt-Chip olt-Chip--info olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--info olt-Chip--withBubble">
   Info
   <span class="olt-Chip-bubble" data-icon="add"></span>
 </span>
@@ -508,19 +508,19 @@ bubble's element. They only work with the default _Chip_.
 - `olt-Chip-bubble--error`
 
 ```bubble-colors.html
-<span class="olt-Chip olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--withBubble">
   Info with icon
   <span class="olt-Chip-bubble olt-Chip-bubble--info" data-icon="add"></span>
 </span>
-<span class="olt-Chip olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--withBubble">
   Success with counter
   <span class="olt-Chip-bubble olt-Chip-bubble--success">42</span>
 </span>
-<span class="olt-Chip olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--withBubble">
   Warning with icon
   <span class="olt-Chip-bubble olt-Chip-bubble--warning" data-icon="add"></span>
 </span>
-<span class="olt-Chip olt-Chip--bubble">
+<span class="olt-Chip olt-Chip--withBubble">
   Error with icon
   <span class="olt-Chip-bubble olt-Chip-bubble--error" data-icon="add"></span>
 </span>

--- a/src/components/Chip/Chip.scss
+++ b/src/components/Chip/Chip.scss
@@ -127,6 +127,12 @@ $chip-colors: (
 .Chip {
   $self: &;
 
+  @at-root {
+    button#{$self} {
+      border: none;
+    }
+  }
+
   display: inline-flex;
   white-space: nowrap;
   vertical-align: middle;
@@ -182,7 +188,7 @@ $chip-colors: (
   // Bubble
   //
 
-  &--bubble {
+  &--withBubble {
     padding-right: 13px;
     margin-right: 8px;
   }
@@ -240,7 +246,7 @@ $chip-colors: (
     }
 
     @at-root {
-      &#{$selector}--bubble {
+      &#{$selector}--withBubble {
         background: chip-bubble-background(map-get($background, 'normal'));
       }
 
@@ -259,7 +265,7 @@ $chip-colors: (
           }
         }
 
-        &#{$selector}--selectable#{$self}--bubble {
+        &#{$selector}--selectable#{$self}--withBubble {
           &:hover {
             background: chip-bubble-background(map-get($background, 'hover'));
 
@@ -292,7 +298,7 @@ $chip-colors: (
           color: map-get($color, 'disabled');
         }
 
-        &.is-disabled#{$self}--bubble {
+        &.is-disabled#{$self}--withBubble {
           background: chip-bubble-background(map-get($background, 'disabled'));
         }
 
@@ -329,10 +335,10 @@ $chip-colors: (
   //
 
   &-bubble,
-  &--selectable#{$self}--bubble:hover #{$self}-bubble,
-  &--selectable#{$self}--bubble:active #{$self}-bubble,
-  &--selectable#{$self}--bubble:focus #{$self}-bubble,
-  &.is-disabled#{$self}--bubble #{$self}-bubble {
+  &--selectable#{$self}--withBubble:hover #{$self}-bubble,
+  &--selectable#{$self}--withBubble:active #{$self}-bubble,
+  &--selectable#{$self}--withBubble:focus #{$self}-bubble,
+  &.is-disabled#{$self}--withBubble #{$self}-bubble {
     &--success,
     &--info,
     &--error,

--- a/src/components/Chip/Chip.scss
+++ b/src/components/Chip/Chip.scss
@@ -127,12 +127,7 @@ $chip-colors: (
 .Chip {
   $self: &;
 
-  @at-root {
-    button#{$self} {
-      border: none;
-    }
-  }
-
+  border: none;
   display: inline-flex;
   white-space: nowrap;
   vertical-align: middle;


### PR DESCRIPTION
- this renames the modifier `--bubble` to `--withBubble` because there is otherwise a js name clash between `--bubble` and `-bubble`. Both would be generated as `olt.ChipBubble`.

- I added a style fix for chips rendered as button elements.