### PR TITLE
fix: textarea default height

### DIFF
--- a/src/controls/TextArea/TextArea.md
+++ b/src/controls/TextArea/TextArea.md
@@ -12,30 +12,30 @@ Input is used with a wrapped `<label>` element that contain
 
 <div class="olt-Grid olt-u-marginTop4 olt-u-marginBottom6">
   <div class="olt-Grid-item olt-Grid-item--3">
-    <div class="demo-input-spacer"></div>
+    <div class="demo-textarea-spacer"></div>
     <div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Empty
       </div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Floating
       </div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Filled
       </div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Disabled
       </div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Required
       </div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Count
       </div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Error
       </div>
-      <div class="demo-input-label">
+      <div class="demo-textarea-label">
         Hint
       </div>
     </div>
@@ -47,37 +47,37 @@ Input is used with a wrapped `<label>` element that contain
         <div class="demo-subtitle-small"></div>
         <div class="olt-Card">
           <div class="olt-Card-content">
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea" placeholder="Your data"></textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label olt-V2Label--floating">
                 <textarea class="olt-TextArea" placeholder="Your data"></textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea" disabled>Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea" required>Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
@@ -88,7 +88,7 @@ Input is used with a wrapped `<label>` element that contain
                 </div>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label has-error">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
@@ -102,7 +102,7 @@ Input is used with a wrapped `<label>` element that contain
                 </div>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
@@ -121,37 +121,37 @@ Input is used with a wrapped `<label>` element that contain
         <div class="demo-subtitle-small"></div>
         <div class="olt-Card olt-Card--dark olt-Theme-dark">
           <div class="olt-Card-content">
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea" placeholder="Your data"></textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label olt-V2Label--floating">
                 <textarea class="olt-TextArea" placeholder="Your data" disabled></textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea" disabled>Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea" required>Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
@@ -162,7 +162,7 @@ Input is used with a wrapped `<label>` element that contain
                 </div>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label has-error">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
@@ -176,7 +176,7 @@ Input is used with a wrapped `<label>` element that contain
                 </div>
               </label>
             </div>
-            <div class="demo-input-content">
+            <div class="demo-textarea-content">
               <label class="olt-V2Label">
                 <textarea class="olt-TextArea">Lorem ipsum</textarea>
                 <span class="olt-V2Label-text">Enter your data</span>
@@ -296,21 +296,6 @@ change. The error messsage can be displayed below the input.
     </span>
   </div>
 </label>
-<label class="olt-V2Label has-error">
-  <textarea class="olt-TextArea">Lorem ipsum</textarea>
-  <span class="olt-V2Label-text">Enter your data</span>
-  <div class="olt-V2Label-icon">
-    <i class="olt-Icon" data-icon="edit"></i>
-  </div>
-  <div class="olt-V2Label-footer">
-    <span class="olt-V2Label-error">
-      Not a valid input
-    </span>
-    <span class="olt-V2Label-count">
-      11/150
-    </span>
-  </div>
-</label>
 ```
 
 ## Hint
@@ -325,21 +310,6 @@ for better user experience.
   <div class="olt-V2Label-footer">
     <span class="olt-V2Label-hint">
       This input is required
-    </span>
-  </div>
-</label>
-<label class="olt-V2Label">
-  <textarea class="olt-TextArea">Lorem ipsum</textarea>
-  <span class="olt-V2Label-text">Enter your data</span>
-  <div class="olt-V2Label-icon">
-    <i class="olt-Icon" data-icon="edit"></i>
-  </div>
-  <div class="olt-V2Label-footer">
-    <span class="olt-V2Label-hint">
-      This input is required
-    </span>
-    <span class="olt-V2Label-count">
-      11/150
     </span>
   </div>
 </label>

--- a/src/controls/TextArea/TextArea.scss
+++ b/src/controls/TextArea/TextArea.scss
@@ -1,8 +1,7 @@
 .TextArea {
   @extend .V2Input;
 
-  height: 31px;
-  min-height: 31px;
+  min-height: 96px;
   min-width: 100%;
   padding: 0 16px;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -294,7 +294,8 @@ a.i-sidebar-list-item:hover b {
   height: 66px;
 }
 
-.demo-input-spacer {
+.demo-input-spacer,
+.demo-textarea-spacer {
   height: 50px;
 }
 
@@ -308,7 +309,8 @@ a.i-sidebar-list-item:hover b {
 }
 
 .demo-label,
-.demo-input-label {
+.demo-input-label,
+.demo-textarea-label {
   font-family: 'Overpass Mono', serif;
   font-size: 12px;
   color: #000;
@@ -327,24 +329,32 @@ a.i-sidebar-list-item:hover b {
   height: 90px;
 }
 
+.demo-textarea-label {
+  height: 140px;
+}
+
 .demo-label:after,
 .demo-label:before,
 .demo-input-label:after,
-.demo-input-label:before {
+.demo-input-label:before,
+.demo-textarea-label:after,
+.demo-textarea-label:before {
   content: '';
   position: absolute;
   left: 0;
 }
 
 .demo-label:before,
-.demo-input-label:before {
+.demo-input-label:before,
+.demo-textarea-label:before {
   border-left: 1px solid #979797;
   top: 0;
   bottom: 0;
 }
 
 .demo-label:after,
-.demo-input-label:after {
+.demo-input-label:after,
+.demo-textarea-label:after {
   border-top: 1px solid #979797;
   height: 0;
   top: 25px;
@@ -355,12 +365,20 @@ a.i-sidebar-list-item:hover b {
   top: 45px;
 }
 
+.demo-textarea-label:after {
+  top: 70px;
+}
+
 .demo-label:first-child:before {
   top: 25px;
 }
 
 .demo-input-label:first-child:before {
   top: 45px;
+}
+
+.demo-textarea-label:first-child:before {
+  top: 70px;
 }
 
 .demo-label:last-child:before {
@@ -371,8 +389,13 @@ a.i-sidebar-list-item:hover b {
   bottom: 45px;
 }
 
+.demo-textarea-label:last-child:before {
+  bottom: 70px;
+}
+
 .demo-content,
-.demo-input-content {
+.demo-input-content,
+.demo-textarea-content {
   height: 50px;
   display: flex;
   align-items: center;
@@ -381,6 +404,10 @@ a.i-sidebar-list-item:hover b {
 
 .demo-input-content {
   height: 90px;
+}
+
+.demo-textarea-content {
+  height: 140px;
 }
 
 .demo-title {


### PR DESCRIPTION
Set default height of textarea to 96px. It was necessary to add new styles for the styleguide to adjust the alignment on the textarea documentation page.