### PR TITLE
Fix Card header

### DIFF
--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -39,6 +39,8 @@
     padding: $card-padding-y $card-padding-x;
     width: 100%;
     display: grid;
+    grid-template-columns: 1fr min-content;
+    grid-template-rows: min-content 1fr;
     grid-gap: calc(var(--spacer) / 4);
   }
 


### PR DESCRIPTION
On https://lightelligence-io.github.io/react/#/Components/Card if we update the button to have some custom margin (as we do in pmd repo) the button starts blinking on resize.

![Example](https://user-images.githubusercontent.com/17011229/68121480-eb179500-ff18-11e9-95f2-e768f85a3906.gif)


